### PR TITLE
feat(workflow): add grace-period-minutes input to auto-close workflow

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run auto-close
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           DRY_RUN_FLAG=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -53,15 +53,20 @@ jobs:
       - name: Run auto-close
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GRACE_PERIOD_INPUT: ${{ inputs.grace_period_minutes }}
         run: |
           DRY_RUN_FLAG=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
-          GRACE_FLAG=""
-          if [ -n "${{ inputs.grace_period_minutes }}" ]; then
-            GRACE_FLAG="--grace-period-minutes ${{ inputs.grace_period_minutes }}"
+          GRACE_ARGS=()
+          if [[ -n "$GRACE_PERIOD_INPUT" ]]; then
+            if [[ "$GRACE_PERIOD_INPUT" =~ ^[0-9]+$ ]]; then
+              GRACE_ARGS=("--grace-period-minutes" "$GRACE_PERIOD_INPUT")
+            else
+              echo "::warning::grace_period_minutes must be a positive integer; ignoring value '$GRACE_PERIOD_INPUT'"
+            fi
           fi
 
           ./simili-cli auto-close \
@@ -69,4 +74,4 @@ jobs:
             --config .github/simili.yaml \
             --verbose \
             $DRY_RUN_FLAG \
-            $GRACE_FLAG
+            "${GRACE_ARGS[@]}"

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,6 +24,11 @@ on:
         options:
           - 'false'
           - 'true'
+      grace_period_minutes:
+        description: 'Grace period in minutes before a potential-duplicate issue is labelled duplicate and closed (overrides config). Leave empty to use the configured default.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -54,8 +59,14 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
 
+          GRACE_FLAG=""
+          if [ -n "${{ inputs.grace_period_minutes }}" ]; then
+            GRACE_FLAG="--grace-period-minutes ${{ inputs.grace_period_minutes }}"
+          fi
+
           ./simili-cli auto-close \
             --repo "${{ github.repository }}" \
             --config .github/simili.yaml \
             --verbose \
-            $DRY_RUN_FLAG
+            $DRY_RUN_FLAG \
+            $GRACE_FLAG

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run auto-close
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           DRY_RUN_FLAG=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/README.md
+++ b/README.md
@@ -220,6 +220,50 @@ Notes:
 - `llm.api_key` can be omitted if `GEMINI_API_KEY` is set.
 - You can override the model at runtime with `LLM_MODEL`.
 
+### `simili auto-close`
+
+Scan all open issues labelled `potential-duplicate` and close those whose grace period has expired with no human activity. Closed issues are relabelled from `potential-duplicate` → `duplicate`.
+
+```bash
+simili auto-close --repo owner/repo --grace-period-minutes 60
+```
+
+**Flags:**
+- `--repo` (required): Target repository (`owner/name`); falls back to `GITHUB_REPOSITORY` env var
+- `--grace-period-minutes`: Override the grace period in minutes for this run (see precedence below)
+- `--dry-run`: Print what would be closed without making any changes
+- `--config`: Path to `simili.yaml` (auto-discovered if omitted)
+
+**Grace period precedence** (highest → lowest):
+
+| Source | How to set |
+|--------|-----------|
+| `--grace-period-minutes` CLI flag | Pass at runtime — overrides everything |
+| `auto_close.grace_period_hours` in `simili.yaml` | Persistent per-repo config |
+| Built-in default | 72 hours (3 days) |
+
+**`simili.yaml` configuration:**
+
+```yaml
+auto_close:
+  grace_period_hours: 48   # default: 72
+  dry_run: false
+```
+
+**Human activity signals** — any of these prevent auto-close:
+1. A negative reaction (👎 or 😕) on the bot's triage comment by a non-bot user.
+2. The issue was reopened by a human after the `potential-duplicate` label was applied.
+3. A non-bot comment posted after the label was applied.
+
+**GitHub Actions usage** — the `auto-close.yml` workflow runs daily at 10:00 UTC and can be triggered manually via `workflow_dispatch` with an optional `grace_period_minutes` input:
+
+```yaml
+# Trigger from GitHub UI or gh CLI:
+gh workflow run auto-close.yml -f grace_period_minutes=60 -f dry_run=false
+```
+
+Leaving `grace_period_minutes` empty uses the value from `simili.yaml` (or the 72 h default).
+
 ## Development
 
 ```bash

--- a/cmd/simili/commands/auto_close_test.go
+++ b/cmd/simili/commands/auto_close_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/similigh/simili-bot/internal/core/config"
+)
+
+// TestGracePeriodMinutesCLIMapping validates the flag-to-config mapping logic:
+//   - An explicit 0 is stored as 1 (smallest positive value, triggers instant expiry in tests).
+//   - Any positive value is stored as-is.
+//   - When the flag was not set, GracePeriodMinutesOverride remains 0 (no override).
+func TestGracePeriodMinutesCLIMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagChanged bool
+		flagValue   int
+		wantOverride int
+	}{
+		{
+			name:         "flag not provided - no override",
+			flagChanged:  false,
+			flagValue:    0,
+			wantOverride: 0,
+		},
+		{
+			name:         "flag set to 0 - stored as 1 (instant expire)",
+			flagChanged:  true,
+			flagValue:    0,
+			wantOverride: 1,
+		},
+		{
+			name:         "flag set to negative - stored as 1 (instant expire)",
+			flagChanged:  true,
+			flagValue:    -5,
+			wantOverride: 1,
+		},
+		{
+			name:         "flag set to 1 - stored as 1",
+			flagChanged:  true,
+			flagValue:    1,
+			wantOverride: 1,
+		},
+		{
+			name:         "flag set to 30 - stored as 30",
+			flagChanged:  true,
+			flagValue:    30,
+			wantOverride: 30,
+		},
+		{
+			name:         "flag set to 1440 (1 day in minutes) - stored as 1440",
+			flagChanged:  true,
+			flagValue:    1440,
+			wantOverride: 1440,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+
+			// Mirrors the mapping logic in runAutoClose.
+			if tt.flagChanged {
+				if tt.flagValue <= 0 {
+					cfg.AutoClose.GracePeriodMinutesOverride = 1
+				} else {
+					cfg.AutoClose.GracePeriodMinutesOverride = tt.flagValue
+				}
+			}
+
+			if cfg.AutoClose.GracePeriodMinutesOverride != tt.wantOverride {
+				t.Errorf("GracePeriodMinutesOverride = %d, want %d",
+					cfg.AutoClose.GracePeriodMinutesOverride, tt.wantOverride)
+			}
+		})
+	}
+}
+
+// TestRepoFlagParsing validates owner/repo splitting used in runAutoClose.
+func TestRepoFlagParsing(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOrg   string
+		wantRepo  string
+		wantValid bool
+	}{
+		{
+			name:      "valid org/repo",
+			input:     "acme-corp/my-service",
+			wantOrg:   "acme-corp",
+			wantRepo:  "my-service",
+			wantValid: true,
+		},
+		{
+			name:      "valid single-word org and repo",
+			input:     "owner/repo",
+			wantOrg:   "owner",
+			wantRepo:  "repo",
+			wantValid: true,
+		},
+		{
+			name:      "missing slash - invalid",
+			input:     "ownerrepo",
+			wantValid: false,
+		},
+		{
+			name:      "empty org - invalid",
+			input:     "/repo",
+			wantValid: false,
+		},
+		{
+			name:      "empty repo - invalid",
+			input:     "owner/",
+			wantValid: false,
+		},
+		{
+			name:      "empty string - invalid",
+			input:     "",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org, repo, ok := strings.Cut(tt.input, "/")
+			valid := ok && org != "" && repo != ""
+
+			if valid != tt.wantValid {
+				t.Errorf("repo %q: valid=%v, want %v", tt.input, valid, tt.wantValid)
+				return
+			}
+			if tt.wantValid {
+				if org != tt.wantOrg {
+					t.Errorf("org = %q, want %q", org, tt.wantOrg)
+				}
+				if repo != tt.wantRepo {
+					t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+				}
+			}
+		})
+	}
+}

--- a/internal/steps/auto_closer_test.go
+++ b/internal/steps/auto_closer_test.go
@@ -189,6 +189,117 @@ func TestReopenedByHuman(t *testing.T) {
 	}
 }
 
+func TestGracePeriodFromConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		minutesOverride int
+		hoursConfig     int
+		wantDuration    time.Duration
+	}{
+		{
+			name:            "minutes override takes precedence over hours config",
+			minutesOverride: 5,
+			hoursConfig:     24,
+			wantDuration:    5 * time.Minute,
+		},
+		{
+			name:            "minutes override of 1 takes precedence over default",
+			minutesOverride: 1,
+			hoursConfig:     0,
+			wantDuration:    1 * time.Minute,
+		},
+		{
+			name:            "hours config used when no minutes override",
+			minutesOverride: 0,
+			hoursConfig:     48,
+			wantDuration:    48 * time.Hour,
+		},
+		{
+			name:            "72-hour default applied when both are zero",
+			minutesOverride: 0,
+			hoursConfig:     0,
+			wantDuration:    72 * time.Hour,
+		},
+		{
+			name:            "hours config of 1 is respected (no default override)",
+			minutesOverride: 0,
+			hoursConfig:     1,
+			wantDuration:    1 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got time.Duration
+			if tt.minutesOverride > 0 {
+				got = time.Duration(tt.minutesOverride) * time.Minute
+			} else {
+				h := tt.hoursConfig
+				if h <= 0 {
+					h = 72
+				}
+				got = time.Duration(h) * time.Hour
+			}
+			if got != tt.wantDuration {
+				t.Errorf("grace period = %v, want %v", got, tt.wantDuration)
+			}
+		})
+	}
+}
+
+func TestGracePeriodMinutesExpiry(t *testing.T) {
+	tests := []struct {
+		name            string
+		minutesOverride int
+		labeledAgo      time.Duration
+		wantExpired     bool
+	}{
+		{
+			name:            "1-minute override: labeled 2 minutes ago - expired",
+			minutesOverride: 1,
+			labeledAgo:      2 * time.Minute,
+			wantExpired:     true,
+		},
+		{
+			name:            "1-minute override: labeled 30 seconds ago - not expired",
+			minutesOverride: 1,
+			labeledAgo:      30 * time.Second,
+			wantExpired:     false,
+		},
+		{
+			name:            "5-minute override: labeled 4 minutes ago - not expired",
+			minutesOverride: 5,
+			labeledAgo:      4 * time.Minute,
+			wantExpired:     false,
+		},
+		{
+			name:            "5-minute override: labeled 6 minutes ago - expired",
+			minutesOverride: 5,
+			labeledAgo:      6 * time.Minute,
+			wantExpired:     true,
+		},
+		{
+			name:            "60-minute override: labeled 59 minutes ago - not expired",
+			minutesOverride: 60,
+			labeledAgo:      59 * time.Minute,
+			wantExpired:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gracePeriod := time.Duration(tt.minutesOverride) * time.Minute
+			labeledAt := time.Now().Add(-tt.labeledAgo)
+			elapsed := time.Since(labeledAt)
+			got := elapsed >= gracePeriod
+			if got != tt.wantExpired {
+				t.Errorf("expiry check: grace=%v, elapsed≈%v => expired=%v, want %v",
+					gracePeriod, tt.labeledAgo, got, tt.wantExpired)
+			}
+		})
+	}
+}
+
 func TestAutoCloseResultCounts(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Description

Adds a `grace_period_minutes` workflow dispatch input to the auto-close workflow, allowing users to manually specify a grace period in minutes. Once the grace period expires, issues labelled `potential-duplicate` are automatically labelled `duplicate` and closed.

Also fixes a 403 permission error that occurred when `GH_PAT` was set but lacked `issues:write` scope — the workflow now uses the built-in `github.token` which already has the correct permissions via the `permissions` block.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update

## Related Issues

Relates to #12

## Changes Made

- Added `grace_period_minutes` input to `workflow_dispatch` in `auto-close.yml` — accepts a number of minutes; leave empty to use the configured default (72 h)
- Passes `--grace-period-minutes` flag to the CLI when the input is set
- Replaced `secrets.GH_PAT` with `github.token` to fix 403 errors caused by an under-scoped PAT; the workflow `permissions: issues: write` block already grants the built-in token everything it needs

## Testing

- [x] I have run `go build ./...` successfully
- [x] I have run `go test ./...` successfully
- [x] I have run `go vet ./...` successfully
- [x] I have tested the changes locally

Manually triggered the workflow with `grace_period_minutes=1` — issues #15 and #16 were successfully labelled `duplicate` and closed within seconds.

## Screenshots (if applicable)

Workflow run output:
```
{
  "processed": 3,
  "closed": 2,
  "skipped_grace_period": 0,
  "skipped_human_activity": 1,
  "details": [
    {
      "number": 16,
      "action": "closed",
      "reason": "grace period expired, no human activity"
    },
    {
      "number": 15,
      "action": "closed",
      "reason": "grace period expired, no human activity"
    },
    {
      "number": 3,
      "action": "skipped_human",
      "reason": "human activity detected after label was applied"
    }
  ]
}

```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The `grace_period_minutes` input overrides the `grace_period_hours` value in `.github/simili.yaml` for that specific run only. The daily scheduled run continues to use the config file value.